### PR TITLE
Support -o wide

### DIFF
--- a/repoScripts/formatUpdater.ps1
+++ b/repoScripts/formatUpdater.ps1
@@ -60,6 +60,22 @@ $addViews = foreach ($command in $commands.Keys) {
 
         # generate format with namespace:
         New-FormatView -name "$name-ns" -props ($props + 'NAMESPACE')
+
+        Write-Host "  - wide"
+        # get the output of the command and subcommand
+        $out = (k $command $sub '-o' 'wide')
+        if ($null -ne $out) {
+            $props = $out[0].psobject.properties.name
+        } else {
+            Write-Warning "Unable to generate format for 'kubectl $command $sub -o wide'. No objects were returned to examine."
+            break
+        }
+
+        # generate plain format with wide:
+        New-FormatView -name "$name-wide" -props ($props)
+
+        # generate formate with namespace and wide:
+        New-FormatView -name "$name-ns-wide" -props ($props + 'NAMESPACE')
     }
 }
 

--- a/src/public/k.ps1
+++ b/src/public/k.ps1
@@ -9,6 +9,7 @@ function k {
         # if the output starts with the typical headers
         if ($out -and ($out[0] -match '^(NAME |NAMESPACE |CURRENT |LAST SEEN )') ) {
             $namespace = $out[0] -match '^NAMESPACE'
+            $wide = $args -contains '-o' -and $args -contains 'wide'
 
             # locate all positions to place semicolons
             # we are using the headers since some values may be null in the data
@@ -31,6 +32,9 @@ function k {
                     $typeName = "$($args[0])-$($pluralCheck)-ns"
                 } else {
                     $typeName = "$($args[0])-$($pluralCheck)"
+                }
+                if ($wide) {
+                    $typeName = "$typeName-wide"
                 }
                 $out -replace ' +;', ';' | ForEach-Object { $_.Trim() } | ConvertFrom-Csv -Delimiter ';' | ForEach-Object { $_.PSObject.TypeNames.Insert(0, $typeName); $_ }
             } else {

--- a/src/public/k.ps1
+++ b/src/public/k.ps1
@@ -8,8 +8,12 @@ function k {
         $out = (& kubectl $args)
         # if the output starts with the typical headers
         if ($out -and ($out[0] -match '^(NAME |NAMESPACE |CURRENT |LAST SEEN )') ) {
+            # check for namespace
             $namespace = $out[0] -match '^NAMESPACE'
-            $wide = $args -contains '-o' -and $args -contains 'wide'
+
+            # check for output wide
+            $checkArgs = $args[2..$args.count]
+            $wide = (($checkArgs -contains '-o' -or $checkArgs -contains '--output') -and $checkArgs -contains 'wide') -or ($checkArgs -contains '--output=wide')
 
             # locate all positions to place semicolons
             # we are using the headers since some values may be null in the data

--- a/src/public/k.ps1
+++ b/src/public/k.ps1
@@ -13,7 +13,23 @@ function k {
 
             # check for output wide
             $checkArgs = $args[2..$args.count]
-            $wide = (($checkArgs -contains '-o' -or $checkArgs -contains '--output') -and $checkArgs -contains 'wide') -or ($checkArgs -contains '--output=wide')
+            $wide = if ($checkArgs -contains '-o') {
+                if ($checkArgs[$checkArgs.IndexOf('-o') + 1] -eq 'wide') {
+                    $true
+                } else {
+                    $false
+                }
+            } elseif ($checkArgs -contains '--output') {
+                if ($checkArgs[$checkArgs.IndexOf('--output') + 1] -eq 'wide') {
+                    $true
+                } else {
+                    $false
+                }
+            } elseif ($checkArgs -contains '--output=wide') {
+                $true
+            } else {
+                $false
+            }
 
             # locate all positions to place semicolons
             # we are using the headers since some values may be null in the data


### PR DESCRIPTION
Fixes #3 

This pull request introduces changes to the PowerShell scripts to enhance the handling of 'wide' output format in Kubernetes commands. The key changes include modifications to the format generation logic and the command execution function to support and properly format the 'wide' output.

Enhancements to format generation and handling:

* [`repoScripts/formatUpdater.ps1`](diffhunk://#diff-63b3b1b5b746d22dd1fc475b12d2a2e7c648a7b2d2b11174025ae80296f195f1R63-R78): Added logic to generate format views for 'wide' output, including formats with and without namespace. This ensures that the script can handle and display the 'wide' output format correctly.

* [`src/public/k.ps1`](diffhunk://#diff-566cc3c54969224193b28d05c6a6a70c463d4a998ed57b6940f90c4e3ec7e8f7R11-R33): Updated the `k` function to detect and handle the 'wide' output format. This includes checking for the '-o wide' and '--output=wide' arguments and adjusting the type name accordingly to include '-wide'. [[1]](diffhunk://#diff-566cc3c54969224193b28d05c6a6a70c463d4a998ed57b6940f90c4e3ec7e8f7R11-R33) [[2]](diffhunk://#diff-566cc3c54969224193b28d05c6a6a70c463d4a998ed57b6940f90c4e3ec7e8f7R56-R58)